### PR TITLE
New method BitmapUtils.getSampled

### DIFF
--- a/droidparts/src/org/droidparts/util/ui/BitmapUtils.java
+++ b/droidparts/src/org/droidparts/util/ui/BitmapUtils.java
@@ -1,17 +1,17 @@
 /**
  * Copyright 2014 Alex Yanchenko
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *  
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
- * limitations under the License. 
+ * limitations under the License.
  */
 package org.droidparts.util.ui;
 
@@ -81,6 +81,25 @@ public final class BitmapUtils {
 		Bitmap bm = Bitmap.createBitmap(view.getDrawingCache());
 		view.setDrawingCacheEnabled(false);
 		return bm;
+	}
+
+	public static Bitmap getSampled(String path, int targetW, int targetH) {
+		// Get the dimensions of the bitmap
+		BitmapFactory.Options bmOptions = new BitmapFactory.Options();
+		bmOptions.inJustDecodeBounds = true;
+		BitmapFactory.decodeFile(path, bmOptions);
+		int photoW = bmOptions.outWidth;
+		int photoH = bmOptions.outHeight;
+
+		// Determine how much to scale down the image
+		int scaleFactor = Math.min(photoW/targetW, photoH/targetH);
+
+		// Decode the image file into a Bitmap sized to fill the View
+		bmOptions.inJustDecodeBounds = false;
+		bmOptions.inSampleSize = scaleFactor;
+		bmOptions.inPurgeable = true;
+
+		return BitmapFactory.decodeFile(path, bmOptions);
 	}
 
 }


### PR DESCRIPTION
Returns bitmap sampled to the nearest power of 2 size, works faster
than scale. Taken from http://developer.android.com/training/camera/photobasics.html#TaskScalePhoto
