### PR TITLE
Fixed exception with inject extras with empty bundle

### DIFF
--- a/droidparts/src/org/droidparts/inner/reader/BundleExtraReader.java
+++ b/droidparts/src/org/droidparts/inner/reader/BundleExtraReader.java
@@ -31,7 +31,7 @@ public class BundleExtraReader {
 		} else {
 			data = FragmentsReader.getFragmentArguments(obj);
 		}
-		Object val = data.get(key);
+		Object val = data != null ? data.get(key) : null;
 		if (val == null && !optional) {
 			throw new Exception("Bundle missing required key: " + key);
 		} else {


### PR DESCRIPTION
I get exception in logcat when I have optional extra bundle in activity and this activity starts with empty bundle (for example start activity with intent filter android.intent.category.LAUNCHER)

Here is code for inject data:

```
@InjectBundleExtra(key = Extra.COVER_IMAGE, optional = true)
protected Bitmap coverImage;
```

Here is exception in logcat:

```
10-08 14:04:22.220    3169-3169/com.example.app D/Injector.inject():107﹕ java.lang.NullPointerException
            at org.droidparts.inner.reader.BundleExtraReader.readVal(BundleExtraReader.java:34)
            at org.droidparts.inner.reader.ValueReader.getVal(ValueReader.java:44)
            at org.droidparts.Injector.inject(Injector.java:100)
            at org.droidparts.Injector.inject(Injector.java:42)
            at org.droidparts.activity.support.v7.ActionBarActivity.onCreate(ActionBarActivity.java:44)
            at com.example.app.ui.activity.AbstractBlurActivity.onCreate(AbstractBlurActivity.java:56)
            at com.example.app.ui.activity.AbstractMenuActivity.onCreate(AbstractMenuActivity.java:74)
            at com.example.app.ui.activity.catalog.CatalogActivity.onCreate(CatalogActivity.java:75)
            at android.app.Activity.performCreate(Activity.java:5104)
            at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1080)
            at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2144)
            at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2230)
            at android.app.ActivityThread.access$600(ActivityThread.java:141)
            at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1234)
            at android.os.Handler.dispatchMessage(Handler.java:99)
            at android.os.Looper.loop(Looper.java:137)
            at android.app.ActivityThread.main(ActivityThread.java:5041)
            at java.lang.reflect.Method.invokeNative(Native Method)
            at java.lang.reflect.Method.invoke(Method.java:511)
            at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:793)
            at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:560)
            at dalvik.system.NativeStart.main(Native Method)
```

This pull request fixes it.
Thank you.
