### PR TITLE
Fixes problem where the setCompoundDrawables() call in setClearIconVisib...

### DIFF
--- a/droidparts/src/org/droidparts/widget/ClearableEditText.java
+++ b/droidparts/src/org/droidparts/widget/ClearableEditText.java
@@ -132,6 +132,9 @@ public class ClearableEditText extends EditText implements OnTouchListener,
 	}
 
 	protected void setClearIconVisible(boolean visible) {
+		boolean wasVisible = getCompoundDrawables()[2] != null;
+        	if(wasVisible == visible) return;
+        	
 		Drawable x = visible ? xD : null;
 		setCompoundDrawables(getCompoundDrawables()[0],
 				getCompoundDrawables()[1], x, getCompoundDrawables()[3]);


### PR DESCRIPTION
...le() is causing an eternal loop of onFocusChanged-events